### PR TITLE
Fix Random.Range bounds in list utilities

### DIFF
--- a/Assets/_GAME/Scripts/Tools/Extentions.cs
+++ b/Assets/_GAME/Scripts/Tools/Extentions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -46,7 +45,7 @@ namespace _GAME
             int count = tmpList.Count;
             for (int i = 0; i < count; i++)
             {
-                var rndIndex = Random.Range(0, tmpList.Count - 1);
+                var rndIndex = Random.Range(0, tmpList.Count);
                 outList.Add(tmpList[rndIndex]);
                 tmpList.RemoveAt(rndIndex);
             }
@@ -73,7 +72,7 @@ namespace _GAME
             
             for (int i = 0; i < count; i++)
             {
-                var rndIndex = Random.Range(0, tmpList.Count - 1);
+                var rndIndex = Random.Range(0, tmpList.Count);
                 outList.Add(tmpList[rndIndex]);
                 tmpList.RemoveAt(rndIndex);
                 if (tmpList.IsNullOrEmpty())


### PR DESCRIPTION
## Summary
- correct Random.Range upper bounds in Shuffle and GetRandomItems
- remove duplicate using directive

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_6897e1602d04832894aa5f7733039aee